### PR TITLE
Allow i18n-cli to do batch processing

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require github.com/stretchr/testify v1.8.2 // indirect
 
 require (
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
-	github.com/sashabaranov/go-gpt3 v1.3.3
+	github.com/sashabaranov/go-openai v1.20.4
 	github.com/spf13/pflag v1.0.5 // indirect
 	golang.org/x/sys v0.5.0 // indirect
 	golang.org/x/text v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -8,8 +8,8 @@ github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLf
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
-github.com/sashabaranov/go-gpt3 v1.3.3 h1:S8Zd4YybnBaNMK+w+XGGWgsjQY1R+6QE2n9SLzVna9k=
-github.com/sashabaranov/go-gpt3 v1.3.3/go.mod h1:BIZdbwdzxZbCrcKGMGH6u2eyGe1xFuX9Anmh3tCP8lQ=
+github.com/sashabaranov/go-openai v1.20.4 h1:095xQ/fAtRa0+Rj21sezVJABgKfGPNbyx/sAN/hJUmg=
+github.com/sashabaranov/go-openai v1.20.4/go.mod h1:lj5b/K+zjTSFxVLijLSTDZuP7adOgerWeFyZLUhAKRg=
 github.com/sirupsen/logrus v1.9.0 h1:trlNQbNUG3OdDrDil03MCb1H2o9nJ1x4/5LYw7byDE0=
 github.com/sirupsen/logrus v1.9.0/go.mod h1:naHLuLoDiP4jHNo9R0sCBMtWGeIprob74mVsIT4qYEQ=
 github.com/spf13/cobra v1.6.1 h1:o94oiPyS4KD1mPy2fmcYYHHfCxLqYjJOhGsCHFZtEzA=

--- a/internal/gpt/gpt.go
+++ b/internal/gpt/gpt.go
@@ -2,13 +2,14 @@ package gpt
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"strings"
 	"sync"
 	"time"
 
-	gogpt "github.com/sashabaranov/go-gpt3"
+	gogpt "github.com/sashabaranov/go-openai"
 )
 
 var ErrTooManyRequests = errors.New("too many requests")
@@ -28,6 +29,10 @@ type Handler struct {
 	cfg     Config
 	index   int
 	clients []*Client
+}
+
+type expectedType struct {
+	Translations []string `json:"translations"`
 }
 
 func New(cfg Config) *Handler {
@@ -70,15 +75,16 @@ func (h *Handler) Translate(ctx context.Context, src, lang string) (string, erro
 	resp, err := client.CreateChatCompletion(ctx, request)
 	if err != nil {
 		var perr *gogpt.APIError
+
 		if errors.As(err, &perr) {
-			if perr.StatusCode == 429 {
+			if perr.HTTPStatusCode == 429 {
 				return "", ErrTooManyRequests
 			}
 		}
 
 		var cerr *gogpt.RequestError
 		if errors.As(err, &cerr) {
-			if cerr.StatusCode == 429 {
+			if cerr.HTTPStatusCode == 429 {
 				return "", ErrTooManyRequests
 			}
 		}
@@ -95,4 +101,58 @@ func (h *Handler) Translate(ctx context.Context, src, lang string) (string, erro
 		result = strings.TrimSpace(resp.Choices[0].Message.Content)
 	}
 	return result, err
+}
+
+func (h *Handler) BatchTranslate(ctx context.Context, srcs []string, lang string) ([]string, error) {
+	ctx, cancel := context.WithTimeout(ctx, h.cfg.Timeout)
+	defer cancel()
+
+	h.Lock()
+	client := h.clients[h.index]
+	h.index = (h.index + 1) % len(h.clients)
+	h.Unlock()
+
+	// Construct the prompt as a single instruction for the model
+	phrasesJSON, _ := json.Marshal(srcs)
+	prompt := fmt.Sprintf("Translate the following phrases into %s, and return the translations as a JSON array (JSON object must be of type {translations: ['a','a'...]}) : %s", lang, string(phrasesJSON))
+
+	// Prepare the chat completion request
+	messages := []gogpt.ChatCompletionMessage{
+		{
+			Role:    "user",
+			Content: prompt,
+		},
+	}
+
+	request := gogpt.ChatCompletionRequest{
+		Model:       "gpt-3.5-turbo-0125",
+		Messages:    messages,
+		MaxTokens:   1024,
+		Temperature: 0.1,
+		ResponseFormat: &gogpt.ChatCompletionResponseFormat{
+			Type: "json_object",
+		},
+		// Stop: []string{"\"],\""}, // Adjust based on how you expect the model to close the JSON array
+	}
+
+	// Perform the chat completion request
+	resp, err := client.CreateChatCompletion(ctx, request)
+	if err != nil {
+		return nil, err
+	}
+
+	// Extract the last message assuming it contains the JSON array with translations
+	if len(resp.Choices) < 1 || len(resp.Choices[0].Message.Content) == 0 {
+		return nil, fmt.Errorf("no translation response received")
+	}
+	lastMessage := resp.Choices[0].Message.Content
+
+	// Parse the JSON array from the last message
+	var translations expectedType
+	err = json.Unmarshal([]byte(lastMessage), &translations)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse translations from response: %w", err)
+	}
+
+	return translations.Translations, nil
 }


### PR DESCRIPTION
Hello,

When using the cli on big files, i noticed two things : 

- Its slow
- It sends too many requests

In order to fix that, I added a new batch capabilities in order to do the processing faster without sending as many requests.

I have also taken the liberty to update the gogpt library being used

new usage : 

`i18n-cli translate --source en-US.json --dir lang --batch 10`

Please feel free to review and I will update the code.

Thanks